### PR TITLE
Declare get_value functions as static.

### DIFF
--- a/ew/avulsion/bmi_avulsion.c
+++ b/ew/avulsion/bmi_avulsion.c
@@ -504,7 +504,7 @@ get_value_ptr(void *self, const char *name, void **dest)
 }
 
 
-int
+static int
 get_value(void * self, const char * name, void *dest)
 {
     void *src = NULL;

--- a/ew/plume/bmi_plume.c
+++ b/ew/plume/bmi_plume.c
@@ -385,7 +385,7 @@ get_value_ptr(void *self, const char *name, void **dest)
 }
 
 
-int
+static int
 get_value(void * self, const char * name, void *dest)
 {
     void *src = NULL;

--- a/ew/subside/bmi_subside.c
+++ b/ew/subside/bmi_subside.c
@@ -390,7 +390,7 @@ get_value_ptr(void *self, const char *name, void **dest)
 }
 
 
-int
+static int
 get_value(void * self, const char * name, void *dest)
 {
     void *src = NULL;


### PR DESCRIPTION
This pull request fixes the declarations of `get_value` for the *Avulsion*, *Plume*, and *Subside* components. Previously, they were (implicitly) external and so when linking to multiple component libraries the `get_value` that was actually being used got confused. Now they are declared as `static int get_value` so that each register function finds its correct `get_value` functions.