### PR TITLE
Fix river discharge setter

### DIFF
--- a/ew/sed/sed_property_file.c
+++ b/ew/sed/sed_property_file.c
@@ -632,9 +632,6 @@ sed_cube_n_rows_between( Sed_cube p , double dz , double lower , double upper , 
         top_row = upper/dz;
 
       n_rows = top_row-bottom_row;
-      fprintf (stderr, "NUMBER of rows is %ld\n", n_rows);
-      fprintf (stderr, "lower row %f\n", lower);
-      fprintf (stderr, "upper row %f\n", upper);
    }
 
    return n_rows;

--- a/ew/sedflux/sedflux_api.c
+++ b/ew/sedflux/sedflux_api.c
@@ -1445,6 +1445,34 @@ sedflux_set_discharge (Sedflux_state* state, const double* val)
 }
 
 
+double
+sedflux_get_channel_suspended_load(Sedflux_state* state)
+{
+  return sed_hydro_nth_concentration(sed_cube_external_river(state->p), 0);
+}
+
+
+double
+sedflux_get_channel_width(Sedflux_state* state)
+{
+  return sed_hydro_width(sed_cube_external_river(state->p));
+}
+
+
+double
+sedflux_get_channel_depth(Sedflux_state* state)
+{
+  return sed_hydro_depth(sed_cube_external_river(state->p));
+}
+
+
+double
+sedflux_get_channel_velocity(Sedflux_state* state)
+{
+  return sed_hydro_velocity(sed_cube_external_river(state->p));
+}
+
+
 void
 sedflux_set_channel_bedload(Sedflux_state* state, const double* val)
 {
@@ -1608,27 +1636,37 @@ sedflux_set_bed_load_flux (Sedflux_state* state, const double* val)
         top_n_total += sorted_flux[i];
       for (i=0; i<n_trunks; i++)
         sorted_flux[i] *= total_flux/top_n_total;
-      eh_watch_dbl (total_flux);
-    
+
       for (i=0; i<n_trunks; i++) {
         Sed_riv* leaves = sed_river_leaves (trunks[i]);
         Sed_riv* leaf;
         const gint n_leaves = g_strv_length ((gchar**)leaves);
-        const double total_thickness = sorted_flux[i] * flux_to_thickness / n_leaves;
+        const double total_thickness = sorted_flux[i] * flux_to_thickness / n_leaves * 10.;
         const Eh_ind_2 sub = sed_cube_sub (c, sorted_ids[i]);
 
         sed_cell_clear (add_cell);
         sed_cell_add_equal_amounts (add_cell, total_thickness);
-        eh_watch_dbl (sed_cell_size (add_cell));
+        // eh_watch_dbl (sed_cell_size (add_cell));
+
+        // sed_river_add_cell (trunks[i], add_cell);
+        // sed_river_set_hinge (trunks[i], sub.i, sub.j);
 
         for (leaf=leaves; *leaf; leaf++) {
           sed_river_add_cell (*leaf, add_cell);
           sed_river_set_hinge (*leaf, sub.i, sub.j);
         }
 
+        {
+          Sed_hydro river_data = sed_cube_external_river(c);
+
+          // sed_hydro_set_velocity(river_data, 1.2);
+          // sed_hydro_set_width(river_data, 400.);
+          // sed_hydro_set_depth(river_data, 4.);
+          sed_hydro_add_cell(river_data, add_cell);
+        }
+
         g_free (leaves);
       }
-
       g_free (trunks);
     }
 

--- a/ew/sedflux/sedflux_api.h
+++ b/ew/sedflux/sedflux_api.h
@@ -63,6 +63,11 @@ void sedflux_set_subaerial_deposition_to (Sedflux_state* state, const double* va
 void sedflux_set_discharge (Sedflux_state* state, const double* val);
 void sedflux_set_bed_load_flux (Sedflux_state* state, const double* val);
 
+double sedflux_get_channel_suspended_load(Sedflux_state* state);
+double sedflux_get_channel_width(Sedflux_state* state);
+double sedflux_get_channel_depth(Sedflux_state* state);
+double sedflux_get_channel_velocity(Sedflux_state* state);
+
 void sedflux_set_channel_bedload(Sedflux_state* state, const double* val);
 void sedflux_set_channel_suspended_load(Sedflux_state* state, const double* val);
 void sedflux_set_channel_width(Sedflux_state* state, const double* val);


### PR DESCRIPTION
This pull request adds BMI setters for some river mouth characteristics. Namely, river velocity, width, and depth. In addition, it fixes the setter for river sediment concentration. The river is now set to "external", which means that the river characteristics are set through BMI setters rather than reading from a file.