### PR TITLE
Set Sed_hydro_file members to NULL with external river.

### DIFF
--- a/ew/sed/sed_hydro.c
+++ b/ew/sed/sed_hydro.c
@@ -1817,7 +1817,15 @@ sed_hydro_file_new( const char*         filename     ,
             fp->data_start   = ftell(fp->fp);
 
          }
-         else
+         else if (type == SED_HYDRO_EXTERNAL) {
+            fp->buf_set = NULL;
+            fp->buf_cur = NULL;
+            fp->buffer_len = 0;
+            fp->n_sig_values = 0;
+            fp->read_hdr = NULL;
+            fp->read_record = NULL;
+            fp->hdr = NULL;
+         } else
             eh_require_not_reached();
 
          fp->data_size    = sizeof(float);
@@ -1848,7 +1856,7 @@ Sed_hydro_file sed_hydro_file_destroy( Sed_hydro_file fp )
    if ( fp )
    {
       fclose( fp->fp );
-      eh_free( fp->file );
+      eh_free(fp->file);
 
       if ( fp->buf_set )
       {
@@ -1861,10 +1869,10 @@ Sed_hydro_file sed_hydro_file_destroy( Sed_hydro_file fp )
       /* If the input file was of type 'inline', there is NULL */
       if ( fp->hdr )
       {
-         eh_free( fp->hdr->comment );
-         eh_free( fp->hdr );
+         eh_free(fp->hdr->comment);
+         eh_free(fp->hdr);
       }
-      eh_free( fp );
+      eh_free(fp);
    }
 
    return NULL;

--- a/ew/sedflux/run_river.c
+++ b/ew/sedflux/run_river.c
@@ -298,19 +298,15 @@ init_river_data( Sed_process proc , Sed_cube prof , GError** error )
 gboolean
 destroy_river( Sed_process p )
 {
-   if ( p )
-   {
-      River_t* data = (River_t*)sed_process_user_data( p );
+   if (p) {
+      River_t* data = (River_t*)sed_process_user_data(p);
       
-      if ( data )
-      {
-         sed_cube_remove_trunk (data->prof, data->this_river);
-
-         sed_hydro_file_destroy( data->fp_river );
-
-         eh_free( data->filename   );
-         eh_free( data->river_name );
-         eh_free( data             );
+      if (data) {
+         sed_cube_remove_trunk(data->prof, data->this_river);
+         sed_hydro_file_destroy(data->fp_river);
+         eh_free(data->filename);
+         eh_free(data->river_name);
+         eh_free(data);
       }
    }
 


### PR DESCRIPTION
This pull request fixes a segmentation fault when the bmi finalize function was called. The problem was that the `Sed_hydro_file` was not properly initialized when an external river was being used.