### PR TITLE
Fix return value for BMI time functions

### DIFF
--- a/ew/avulsion/bmi_avulsion.c
+++ b/ew/avulsion/bmi_avulsion.c
@@ -101,7 +101,7 @@ static int
 get_end_time(void * self, double *time)
 { /* Implement this: Set end time */
     *time = avulsion_get_end_time ((AvulsionModel*)self);
-    return BMI_FAILURE;
+    return BMI_SUCCESS;
 }
 
 
@@ -109,7 +109,7 @@ static int
 get_current_time(void * self, double *time)
 { /* Implement this: Set current time */
     *time = avulsion_get_current_time ((AvulsionModel*)self);
-    return BMI_FAILURE;
+    return BMI_SUCCESS;
 }
 
 
@@ -117,7 +117,7 @@ static int
 get_time_step(void * self, double *dt)
 { /* Implement this: Set time step */
     *dt = ((AvulsionModel*)self)->time_step;
-    return BMI_FAILURE;
+    return BMI_SUCCESS;
 }
 
 

--- a/ew/subside/bmi_subside.c
+++ b/ew/subside/bmi_subside.c
@@ -82,7 +82,7 @@ static int
 get_end_time(void * self, double *time)
 { /* Implement this: Set end time */
     *time = -1.;
-    return BMI_FAILURE;
+    return BMI_SUCCESS;
 }
 
 
@@ -90,7 +90,7 @@ static int
 get_current_time(void * self, double *time)
 { /* Implement this: Set current time */
     *time = -1.;
-    return BMI_FAILURE;
+    return BMI_SUCCESS;
 }
 
 
@@ -98,7 +98,7 @@ static int
 get_time_step(void * self, double *dt)
 { /* Implement this: Set time step */
     *dt = -1.;
-    return BMI_FAILURE;
+    return BMI_SUCCESS;
 }
 
 


### PR DESCRIPTION
The pull request fixes the *BMI* time functions so that they return *BMI_SUCCESS*, when they are successful (which is all the time).